### PR TITLE
[MISC] Use skopeo built-in with rockcraft 

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -81,7 +81,7 @@ jobs:
           TRACK=${{ needs.release_checks.outputs.track }}
           if [ ! -z "$RISK" ] && [ "${RISK}" != "no-risk" ]; then TAG=${TRACK}_${RISK}; else TAG=${TRACK}; fi
       
-          IMAGE_NAME="ghcr.io/deusebio/charmed-karapace"
+          IMAGE_NAME="ghcr.io/canonical/charmed-karapace"
 
           ROCK_FILE=${{ needs.build.outputs.rock }}
 

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -58,9 +58,10 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
-      - name: Install yq
+      - name: Install dependencies
         run: |
           sudo snap install yq
+          sudo snap install rockcraft --classic --edge    
 
       - uses: actions/download-artifact@v3
         with:

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -58,10 +58,6 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
-      - name: Install skopeo
-        run: |
-          sudo snap install --devmode --channel edge skopeo
-
       - name: Install yq
         run: |
           sudo snap install yq
@@ -84,11 +80,11 @@ jobs:
           TRACK=${{ needs.release_checks.outputs.track }}
           if [ ! -z "$RISK" ] && [ "${RISK}" != "no-risk" ]; then TAG=${TRACK}_${RISK}; else TAG=${TRACK}; fi
       
-          IMAGE_NAME="ghcr.io/canonical/charmed-karapace"
+          IMAGE_NAME="ghcr.io/deusebio/charmed-karapace"
 
           ROCK_FILE=${{ needs.build.outputs.rock }}
 
-          sudo skopeo --insecure-policy copy \
+          sudo rockcraft.skopeo --insecure-policy copy \
             oci-archive:${ROCK_FILE} \
             docker-daemon:${IMAGE_NAME}:${TAG}
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-
 # Charmed Karapace ROCK
 
 [![Container Registry](https://img.shields.io/badge/Container%20Registry-published-blue)](https://github.com/canonical/charmed-karapace-rock/pkgs/container/charmed-karapace)

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+
 # Charmed Karapace ROCK
 
 [![Container Registry](https://img.shields.io/badge/Container%20Registry-published-blue)](https://github.com/canonical/charmed-karapace-rock/pkgs/container/charmed-karapace)


### PR DESCRIPTION
We should be using the `skopeo` that is built-in with rockcraft, as the mismatch between the two seems to provide some compatibility issues. 