### PR TITLE
Add sentry package

### DIFF
--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -30,7 +30,9 @@ parts:
     source: https://github.com/Aiven-Open/karapace.git
     source-tag: 3.12.0
     python-requirements:
-        - ./requirements/requirements.txt
+      - ./requirements/requirements.txt
+    python-packages:
+      - sentry_sdk
     stage-packages:
       - python3.10-venv
       - util-linux


### PR DESCRIPTION
Adds missing sentry package. This removes warnings on the service when executing commands like:
```
root@karapace-k8s-0:/# karapace --version                     
Cannot enable Sentry.io sending: importing 'sentry_sdk' failed
3.12.0                                                        
```